### PR TITLE
去除飞书SMTP

### DIFF
--- a/biliclear.py
+++ b/biliclear.py
@@ -87,8 +87,7 @@ if not exists("./config.json"):
         "@sohu.com": {"server": "smtp.sohu.com", "port": 465},
         "@hotmail.com": {"server": "smtp.live.com", "port": 587},
         "@outlook.com": {"server": "smtp.office365.com", "port": 587},
-        "@qq.com": {"server": "smtp.qq.com", "port": 465},
-        "@feishu.cn": {"server": "smtp.feishu.cn", "port": 465}
+        "@qq.com": {"server": "smtp.qq.com", "port": 465}
     }
     
     print("\nSMTP 服务器:")


### PR DESCRIPTION
飞书的公共邮箱不能使用@feishu.cn后缀
只能使用自己的域名

可以使用dnspython 查询MX记录
查找对应的邮箱提供商