### PR TITLE
复杂的文字变种识别

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -176,3 +176,9 @@ pyrightconfig.json
 # End of https://www.toptal.com/developers/gitignore/api/python
 
 config.json
+
+### Python Editors ###
+# Visual Studio Code
+.vscode/
+# PyCharm
+.idea/

--- a/biliclear.py
+++ b/biliclear.py
@@ -18,6 +18,7 @@ import numpy as np
 import biliauth
 import syscmds
 import gpt
+from utils import VarietyString
 
 sys.excepthook = lambda *args: [print("^C"), exec("raise SystemExit")] if KeyboardInterrupt in args[0].mro() else sys.__excepthook__(*args)
 
@@ -211,6 +212,7 @@ def getReplys(avid: str | int):
 
 def isPorn(text: str):
     "判断评论是否为色情内容 (使用规则, rules.txt)"
+    text = VarietyString(text)
     for rule in rules:
         if eval(rule):  # 一般来说, 只有rules.txt没有投毒, 就不会有安全问题
             return True, rule

--- a/res/rules.txt
+++ b/res/rules.txt
@@ -29,7 +29,7 @@
 "零零" in text and "喜欢吃" in text
 "停一停" in text and "沿途" in text and "吧" in text and "的" in text and "海洋" in text
 "停一停" in text and "沿途" in text and "吧" in text and "的" in text and "一次" in text
-"好看" in text and "燃烧" in text and "哦" in text and ("！" in text or "!" in text)
+"好看" in text and "燃烧" in text and "哦" in text and "！" in text
 "开心一次" in text and "是" in text and "流转" in text and "不经意" in text
 "都是" in text and "]" in text and "刚才" in text and "好大" in text
 "友情提示" in text and "刷视频" in text
@@ -39,4 +39,4 @@
 "isgou.cn" in text
 "出汗" in text and "新动作" in text
 "QWAH.cznnew.cn" in text
-"V" in text and "扫" in text or "v" in text and "扫" in text
+"V" in text and "扫" in text

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,1 @@
+from BiliClear.utils.variety_string import *

--- a/utils/variety_string.py
+++ b/utils/variety_string.py
@@ -1,0 +1,61 @@
+from typing import SupportsIndex
+from typing import Sequence, TypeVar
+
+variety = [
+    'AaＡａ', 'BbＢｂ', 'CcＣｃ', 'DdＤｄ', 'EeＥｅ', 'FfＦｆ', 'GgＧｇ', 'HhＨｈ',
+    'IiＩｉ', 'JjＪｊ', 'KkＫｋ', 'LlＬｌ', 'MmＭｍ', 'NnＮｎ', 'OoＯｏ', 'PpＰｐ',
+    'QqＱｑ', 'RrＲｒ', 'SsＳｓ', 'TtＴｔ', 'UuＵｕ', ['V', 'v', 'Ｖ', 'ｖ', '\/'],
+    ['W', 'w', 'Ｗ', 'ｗ', 'VV'], 'XxＸｘ', 'YyＹｙ', 'ZzＺｚ', '0Oo００ｏ', '1１',
+    '2２', '3３', '4４', '5５', '6６', '7７', '8８', '9９', ['掃', '扫', 'SA0'], '!！', 
+    '[【', ']】', ',，'
+]
+
+def convert(original: str) -> str:
+    for strings in variety:
+        for char in strings:
+            original = original.replace(char, strings[0])
+    return original
+
+class VarietyString(str):
+    """复杂变体的识别，例如“Ｓａo 码”"""
+    def __eq__(self, other: str):
+        return convert(self) == convert(other)
+    
+    def startswith(self, prefix: str | tuple[str, ...], start: SupportsIndex | None = None, end: SupportsIndex | None = None) -> bool:
+        return convert(self).startswith(convert(prefix), start, end)
+
+    def removeprefix(self, prefix: str) -> str:
+        return convert(self).removeprefix(convert(prefix))
+    
+    def removesuffix(self, suffix: str) -> str:
+        return convert(self).removesuffix(convert(suffix))
+
+    def count(self, x: str, start: SupportsIndex | None = None, end: SupportsIndex | None = None) -> int:
+        return convert(self).count(convert(x), start, end)
+    
+    def __contains__(self, key: str) -> bool:
+        return convert(key) in convert(self)
+
+def test():
+    import unittest
+
+    class VarietyStringTest(unittest.TestCase):
+        def test_equal(self):
+            self.assertEqual(VarietyString('aAaＡａ'), 'AaａＡa')
+            self.assertNotEqual(VarietyString('aAaＡａ'), 'aAaＡａａ')
+            self.assertEqual(VarietyString('掃扫'), 'ＳaosａO')
+            self.assertNotEqual(VarietyString('BbＢｂ'), 'BｃＢｂ')
+        
+        def test_startswith(self):
+            self.assertTrue(VarietyString('Aａa掃Ａ').startswith('ＡAａsao'))
+            self.assertFalse(VarietyString('Aａa掃Ａ').startswith('ＡAｂsao'))
+        
+        def test_removeprefix(self):
+            self.assertEqual(VarietyString('A掃aＡａ').removeprefix('ａsao'), 'AAA')
+            self.assertEqual(VarietyString('A掃aＡａ').removeprefix('Ｓsao'), 'A掃AAA')
+
+    # 运行测试
+    unittest.main(VarietyStringTest())
+
+if __name__ == '__main__':
+    test()


### PR DESCRIPTION
例如“Ｓａo 码加 \\/：”。

```python
def test():
    import unittest

    class VarietyStringTest(unittest.TestCase):
        def test_equal(self):
            self.assertEqual(VarietyString('aAaＡａ'), 'AaａＡa')
            self.assertNotEqual(VarietyString('aAaＡａ'), 'aAaＡａａ')
            self.assertEqual(VarietyString('掃扫'), 'ＳaosａO')
            self.assertNotEqual(VarietyString('BbＢｂ'), 'BｃＢｂ')
        
        def test_startswith(self):
            self.assertTrue(VarietyString('Aａa掃Ａ').startswith('ＡAａsao'))
            self.assertFalse(VarietyString('Aａa掃Ａ').startswith('ＡAｂsao'))
        
        def test_removeprefix(self):
            self.assertEqual(VarietyString('A掃aＡａ').removeprefix('ａsao'), 'AAA')
            self.assertEqual(VarietyString('A掃aＡａ').removeprefix('Ｓsao'), 'A掃AAA')

    # 运行测试
    unittest.main(VarietyStringTest())
```

没有网易邮箱不方便测试，简单写了个单元测试。
